### PR TITLE
MAM TLD for london collisions

### DIFF
--- a/lib/Net/DRI/DRD/NGTLD.pm
+++ b/lib/Net/DRI/DRD/NGTLD.pm
@@ -693,7 +693,7 @@ Contested: basketball group music
 
  return {
      bep_type => 1, # dedicated registry
-     tlds => ['london', 'review', 'rugby',
+     tlds => ['london', 'london-collisions', 'review', 'rugby',
               'basketball', 'group', 'music', 
              ],
      whois_server => (defined $tld && $tld =~ m/\w+/ ? 'whois.nic.' . $tld : undef),


### PR DESCRIPTION
MAM created a shadow TLD for collision names (.london-collisions).

They will have the same process for .BAYERN. The shadow TLD for .bayern is .bayern-collisions.
