### PR TITLE
bug fix

### DIFF
--- a/lib/Net/DRI/Protocol/EPP/Extensions/TANGO.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/TANGO.pm
@@ -30,7 +30,7 @@ sub setup
  $self->capabilities('domain_update','auction',['set']);
 }
 
-sub default_extensions { return qw/GracePeriod SecDNS LaunchPhase TANGO::IDN TANGO::Auction TANGO::LaunchPhase/; }
+sub default_extensions { return qw/GracePeriod SecDNS LaunchPhase TANGO::IDN TANGO::Auction/; }
 
 ####################################################################################################
 1;


### PR DESCRIPTION
Hi Michael,

My bad here: http://goo.gl/Iz6mTt
TANGO should not use this LaunchPhase extension since those extra elements: ext:augmentedMark and ext:applicationInfo are only mandatory for CORENIC.

Cheers,
Paulo