### PR TITLE
fix afiliassrs whois server

### DIFF
--- a/lib/Net/DRI/DRD/NGTLD.pm
+++ b/lib/Net/DRI/DRD/NGTLD.pm
@@ -299,7 +299,7 @@ xxx xn--3ds443g xn--4gbrim xn--fiq228c5hs xn--kput3i adult bnpparibas creditunio
      bep_type => 2, # shared registry
      tlds => ['xxx','xn--3ds443g','xn--4gbrim','xn--fiq228c5hs','xn--kput3i','adult','bnpparibas','creditunion','ged','global','hiv','indians','ltda','onl','porn','rich','storage','vegas','vote','voto'],
      transport_protocol_default => ['Net::DRI::Transport::Socket',{},'Net::DRI::Protocol::EPP::Extensions::AfiliasSRS',{}],
-     whois_server => 'whois.afilias.net',
+     whois_server => (defined $tld && $tld =~ m/\w+/ ? 'whois.nic.' . $tld : undef),
    } if $bep eq 'afiliassrs';
 
 =pod


### PR DESCRIPTION
Hi Michael,

The previous whois server is correct if $bep is afilias but not for afiliassrs.

Cheers,
Paulo