### PR TITLE
Es dom renew

### DIFF
--- a/lib/Net/DRI/Protocol/EPP/Extensions/ES/Domain.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/ES/Domain.pm
@@ -165,8 +165,23 @@ sub renew
 {
  my ($epp,$domain,$rd)=@_;
  my $mes=$epp->message();
+
+ # core + mandatory Registry exDate format
+ my $curexp=Net::DRI::Util::has_key($rd,'current_expiration')? $rd->{current_expiration} : undef;
+ Net::DRI::Exception::usererr_insufficient_parameters('current expiration date') unless defined($curexp);
+ $curexp=$curexp->clone()->set_time_zone('UTC')->strftime('%Y-%m-%d') if (ref($curexp) && Net::DRI::Util::check_isa($curexp,'DateTime'));
+ Net::DRI::Exception::usererr_invalid_parameters('current expiration date must be YYYY-MM-DD') unless $curexp=~m/^\d{4}-\d{2}-\d{2}$/;
+ $curexp = $curexp . 'T00:00:00.01'; # now we append this since it's mandotory for this command
+ my @d=Net::DRI::Protocol::EPP::Util::domain_build_command($mes,'renew',$domain);
+ push @d,['domain:curExpDate',$curexp];
+ push @d,Net::DRI::Protocol::EPP::Util::build_period($rd->{duration}) if Net::DRI::Util::has_duration($rd);
+ $mes->command_body(\@d);
+
+ # extension
  push $mes->{'command_body'},['domain:renewOp','accept'];  
  domain_extension($mes,$rd);
+
+ return;
 }
 
 sub transfer_request

--- a/lib/Net/DRI/Protocol/EPP/Extensions/ES/Domain.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/ES/Domain.pm
@@ -173,12 +173,11 @@ sub renew
  Net::DRI::Exception::usererr_invalid_parameters('current expiration date must be YYYY-MM-DD') unless $curexp=~m/^\d{4}-\d{2}-\d{2}$/;
  $curexp = $curexp . 'T00:00:00.01'; # now we append this since it's mandotory for this command
  my @d=Net::DRI::Protocol::EPP::Util::domain_build_command($mes,'renew',$domain);
+ push @d,['domain:renewOp','accept'];
  push @d,['domain:curExpDate',$curexp];
  push @d,Net::DRI::Protocol::EPP::Util::build_period($rd->{duration}) if Net::DRI::Util::has_duration($rd);
  $mes->command_body(\@d);
 
- # extension
- push $mes->{'command_body'},['domain:renewOp','accept'];  
  domain_extension($mes,$rd);
 
  return;

--- a/t/658es_epp.t
+++ b/t/658es_epp.t
@@ -115,7 +115,7 @@ $R2=$E1.'<response>'.r().'<resData><domain:renData xmlns:domain="urn:ietf:params
 my $du = DateTime::Duration->new( years => 2);
 my $exp = DateTime->new(year  => 2013,month => 01,day   => 01);
 $rc = $dri->domain_renew('test1.es',{duration=>$du,current_expiration=>$exp} );
-is($R1,$E1.'<command><renew><domain:renew xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd"><domain:name>test1.es</domain:name><domain:curExpDate>2013-01-01T00:00:00.01</domain:curExpDate><domain:period unit="y">2</domain:period><domain:renewOp>accept</domain:renewOp></domain:renew></renew>'.$ES_EXT.'<clTRID>ABC-12345</clTRID></command></epp>', 'domain_renew build');
+is($R1,$E1.'<command><renew><domain:renew xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd"><domain:name>test1.es</domain:name><domain:renewOp>accept</domain:renewOp><domain:curExpDate>2013-01-01T00:00:00.01</domain:curExpDate><domain:period unit="y">2</domain:period></domain:renew></renew>'.$ES_EXT.'<clTRID>ABC-12345</clTRID></command></epp>', 'domain_renew build');
 is($rc->is_success(), 1, 'domain_renew is success');
 is($dri->get_info('exDate'),'2015-01-01T00:00:00','domain_renew get_info(exDate)');
 

--- a/t/658es_epp.t
+++ b/t/658es_epp.t
@@ -111,11 +111,11 @@ is($R1,$E1.'<command><update><domain:update xmlns:domain="urn:ietf:params:xml:ns
 is($rc->is_success(), 1, 'domain_update is success');
 
 #renew
-$R2=$E1.'<response>'.r().'<resData><domain:renData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd"><domain:name>test1.es</domain:name><domain:exDate>2015-01-01T00:00:00.00</domain:exDate></domain:renData></resData>'.$TRID.'</response>'.$E2;
-my $du = DateTime::Duration->new( years => 1);
+$R2=$E1.'<response>'.r().'<resData><domain:renData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd"><domain:name>test1.es</domain:name><domain:exDate>2015-01-01T00:00:00.01</domain:exDate></domain:renData></resData>'.$TRID.'</response>'.$E2;
+my $du = DateTime::Duration->new( years => 2);
 my $exp = DateTime->new(year  => 2013,month => 01,day   => 01);
 $rc = $dri->domain_renew('test1.es',{duration=>$du,current_expiration=>$exp} );
-is($R1,$E1.'<command><renew><domain:renew xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd"><domain:name>test1.es</domain:name><domain:curExpDate>2013-01-01</domain:curExpDate><domain:period unit="y">1</domain:period><domain:renewOp>accept</domain:renewOp></domain:renew></renew>'.$ES_EXT.'<clTRID>ABC-12345</clTRID></command></epp>', 'domain_renew build');
+is($R1,$E1.'<command><renew><domain:renew xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd"><domain:name>test1.es</domain:name><domain:curExpDate>2013-01-01T00:00:00.01</domain:curExpDate><domain:period unit="y">2</domain:period><domain:renewOp>accept</domain:renewOp></domain:renew></renew>'.$ES_EXT.'<clTRID>ABC-12345</clTRID></command></epp>', 'domain_renew build');
 is($rc->is_success(), 1, 'domain_renew is success');
 is($dri->get_info('exDate'),'2015-01-01T00:00:00','domain_renew get_info(exDate)');
 


### PR DESCRIPTION
Hi Michael,

For this registry we need to append extra information for the expiration date when we use the domain_renew() command. I confirmed with the Registry and the time expected is always the same (T00:00:00.01). If we don't do that they return that the date is incorrect.

We also need to use send <domain:renewOp> element as the same order as displayed in the manual or the action will fail.

Cheers,
Paulo
