### PR TITLE
update to TLSv12 - more secure

### DIFF
--- a/lib/Net/DRI/Protocol/EPP/Connection.pm
+++ b/lib/Net/DRI/Protocol/EPP/Connection.pm
@@ -104,7 +104,7 @@ sub write_message
 sub transport_default
 {
  my ($self,$tname)=@_;
- return (defer => 0, socktype => 'ssl', ssl_version => 'TLSv1', remote_port => 700);
+ return (defer => 0, socktype => 'ssl', ssl_version => 'TLSv12', remote_port => 700);
 }
 
 #  SSL_verify_callback

--- a/lib/Net/DRI/Protocol/RRP/Connection.pm
+++ b/lib/Net/DRI/Protocol/RRP/Connection.pm
@@ -165,7 +165,7 @@ sub find_code
 sub transport_default
 {
  my ($self,$tname)=@_;
- return (defer => 0, socktype => 'ssl', ssl_version => 'TLSv1', remote_port => 648);
+ return (defer => 0, socktype => 'ssl', ssl_version => 'TLSv12', remote_port => 648);
 }
 
 ####################################################################################################

--- a/lib/Net/DRI/Protocol/TMCH/Connection.pm
+++ b/lib/Net/DRI/Protocol/TMCH/Connection.pm
@@ -67,7 +67,7 @@ sub write_message
 sub transport_default
 {
  my ($self,$tname)=@_;
- return (defer => 0, socktype => 'ssl', ssl_version => 'TLSv1', remote_port => 700);
+ return (defer => 0, socktype => 'ssl', ssl_version => 'TLSv12', remote_port => 700);
 }
 
 #  SSL_verify_callback


### PR DESCRIPTION
Hi Michael,

Donuts disabled support for TLS v1.0. They only accept new and more secure versions of this protocol - 1.1 and 1.2.

I forced to use the last one.

Cheers,
Paulo Jorge