### PR TITLE
enable fee-0.7 extension for UNIREG

### DIFF
--- a/lib/Net/DRI/DRD/NGTLD.pm
+++ b/lib/Net/DRI/DRD/NGTLD.pm
@@ -1186,7 +1186,7 @@ L<Net::DRI::Protocol::EPP::Extensions::VeriSign::Sync> http://www.verisign.com/e
  return {
      bep_type => 2, # shared registry
      tlds => ['art','audio','auto','blackfriday','car','cars','christmas','click','deal','diet','flowers','free','game','garden','gift','guitars','help','hiphop','hiv','home','hosting','inc','juegos','link','lol','mom','photo','pics','property','realestate','save','sexy','shopping','store','tattoo','yoga'],
-     transport_protocol_default => ['Net::DRI::Transport::Socket',{},'Net::DRI::Protocol::EPP::Extensions::UNIREG',{}],
+     transport_protocol_default => ['Net::DRI::Transport::Socket',{},'Net::DRI::Protocol::EPP::Extensions::UNIREG',{'brown_fee_version' => '0.7'}],
      factories => [ {'object'=>'contact','factory' => sub { return Net::DRI::Data::Contact::UNIREG->new(@_); } } ],
      requires => [ 'Net::DRI::Data::Contact::UNIREG'],
      whois_server => 'whois.uniregistry.net',


### PR DESCRIPTION
(cars|car|auto): "As a reminder, EAP registrations over EPP require the use of the fee-0.7 EPP extension."