### PR TITLE
Adding fee namespace version 0.11 support in CentralNic/Fee

### DIFF
--- a/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
@@ -422,7 +422,7 @@ sub check_parse
   my ($po,$otype,$oaction,$oname,$rinfo)=@_;
   my $mes=$po->message();
   return unless $mes->is_success;
-  my $version = (($mes->ns('fee')=~m!fee-(\d\.\d)!)) ? "$1" : '0.4';
+  my $version = (($mes->ns('fee')=~m!fee-(\d\.\d+)!)) ? "$1" : '0.4';
 
   my $chkdata=$mes->node_extension if ($version eq '0.4');
   $chkdata=$mes->get_extension($mes->ns('fee'),'chkData') if ($version eq '0.5' || $version eq '0.6' || $version eq '0.7' || $version eq '0.8' || $version eq '0.9');

--- a/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
@@ -191,7 +191,7 @@ sub fee_set_parse
     }
     elsif ($name eq 'objID') # in 0.9 we can have an objId with element
     {
-      my $element = $content->hasAttribute('element') ? $content->hasAttribute('element') : 'name';
+      my $element = $content->hasAttribute('element') ? $content->getAttribute('element') : 'name';
       $set->{'element'} = $element;
       $set->{'domain'} = $content->textContent(); # we don' support other types at the moment
       $set->{'premium'} = 0; # actually this was only in 0.6, but this sort of keeps things going in the same vain implementation wise

--- a/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
@@ -425,7 +425,7 @@ sub check_parse
   my $version = (($mes->ns('fee')=~m!fee-(\d\.\d+)!)) ? "$1" : '0.4';
 
   my $chkdata=$mes->node_extension if ($version eq '0.4');
-  $chkdata=$mes->get_extension($mes->ns('fee'),'chkData') if ($version eq '0.5' || $version eq '0.6' || $version eq '0.7' || $version eq '0.8' || $version eq '0.9');
+  $chkdata=$mes->get_extension($mes->ns('fee'),'chkData') if ($version eq '0.5' || $version eq '0.6' || $version eq '0.7' || $version eq '0.8' || $version eq '0.9' || $version eq '0.11');
   return unless defined $chkdata;
 
   foreach my $el (Net::DRI::Util::xml_list_children($chkdata))
@@ -434,10 +434,15 @@ sub check_parse
     if ($name =~ m/^(chkData|cd)$/) # chkData for 0.4, cd for 0.5 & 0.6 & 0.7 & 0.8
     {
       my $dn = '';
-      foreach my $el2 (Net::DRI::Util::xml_list_children($content))
-      {
-        my ($name2,$content2)=@$el2;
-        $dn = $content2->textContent() if $name2 =~ m/^(domain|name|objID)$/; # domain for 0.4, name for 0.5 & 0.6 & 0.7 & 0.8, and objID for 0.9
+      if ($version eq '0.11') {
+       $dn = Net::DRI::Util::xml_traverse($content, $mes->ns('fee'), qw/object name/);
+       $dn = $dn->textContent() if defined $dn;
+      } else {
+       foreach my $el2 (Net::DRI::Util::xml_list_children($content))
+       {
+         my ($name2,$content2)=@$el2;
+         $dn = $content2->textContent() if $name2 =~ m/^(domain|name|objID)$/; # domain for 0.4, name for 0.5 & 0.6 & 0.7 & 0.8, and objID for 0.9
+       }
       }
       next unless $dn;
       my $fee_set = ($version eq '0.4') ? fee_set_parse_legacy($content) : fee_set_parse($version, $content);

--- a/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
@@ -440,8 +440,7 @@ sub check_parse
         $dn = $content2->textContent() if $name2 =~ m/^(domain|name|objID)$/; # domain for 0.4, name for 0.5 & 0.6 & 0.7 & 0.8, and objID for 0.9
       }
       next unless $dn;
-      my $fee_set = fee_set_parse_legacy($content) if ($version eq '0.4');
-      $fee_set = fee_set_parse($version, $content) if ($version ne '0.4');
+      my $fee_set = ($version eq '0.4') ? fee_set_parse_legacy($content) : fee_set_parse($version, $content);
       if ($fee_set)
       {
         push @{$rinfo->{domain}->{$dn}->{fee}},$fee_set;

--- a/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/CentralNic/Fee.pm
@@ -144,6 +144,8 @@ sub parse_greeting
  eval { $po->switch_to_highest_namespace_version('fee'); }; # dont crash if server hasn't announced
 }
 
+## returns an integer for easier comparisons
+sub ver { my ($mes)= @_; my ($ver)=($mes->ns('fee')=~m/-0.(\d+)$/); return $ver; }
 
 ####################################################################################################
 ## Build / Parse helpers for 0.5 to 0.8


### PR DESCRIPTION
For now, only domain:check is supported. Further commits will add other EPP operations.
This has been tested with an EPP server implementing fee namespace version 0.11